### PR TITLE
Use the webRequest API to intercept and redirect requests

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,13 +9,17 @@
     "48": "icons/toxcancel-48.svg"
   },
 
-  "content_scripts": [
-    {
-      "matches": ["*://*.x.com/*"],
-      "js": ["toxcancel.js"]
-    }
+  "permissions": [
+    "webRequest",
+    "webRequestBlocking"
+  ],
+  "host_permissions": [
+    "*://*.x.com/*"
   ],
 
+  "background": {
+    "scripts": ["toxcancel.js"]
+  },
 
   "browser_specific_settings": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
     "webRequestBlocking"
   ],
   "host_permissions": [
-    "*://*.x.com/*"
+    "*://*.x.com/*",
+    "*://*.twitter.com/*"
   ],
 
   "background": {

--- a/toxcancel.js
+++ b/toxcancel.js
@@ -12,7 +12,7 @@ function redirect(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
 	redirect,
 	{
-		urls: ["*://*.x.com/*"],
+		urls: ["*://*.x.com/*", "*://*.twitter.com/*"],
 		types: ["main_frame"],
 	},
 	["blocking"],

--- a/toxcancel.js
+++ b/toxcancel.js
@@ -1,6 +1,19 @@
-var location = window.location;
-var currentLoc = location.href;
-var newLoc = "https://xcancel.com" + // don't just replace x.com with xcancel.com since mobile.xcancel.com does not exist
-	location.pathname; // skip a potential query string since it is not supported by xcancel
-console.log("redirect from " + currentLoc + " to " + newLoc);
-location.replace(newLoc);
+"use strict";
+
+function redirect(requestDetails) {
+	const originalUrl = new URL(requestDetails.url);
+	const redirectUrl =
+		"https://xcancel.com" + // don't just replace x.com with xcancel.com since mobile.xcancel.com does not exist
+		originalUrl.pathname; // skip a potential query string since it is not supported by xcancel
+	console.log(`redirect from ${originalUrl} to ${redirectUrl}`);
+	return { redirectUrl: redirectUrl };
+}
+
+browser.webRequest.onBeforeRequest.addListener(
+	redirect,
+	{
+		urls: ["*://*.x.com/*"],
+		types: ["main_frame"],
+	},
+	["blocking"],
+);


### PR DESCRIPTION
This makes the browser send no requests to x.com, as the redirect is performed before any request is sent out.
It also redirects twitter.com.